### PR TITLE
Update pcache RFC with test result section

### DIFF
--- a/pcache/pcache_RFC_V2.md
+++ b/pcache/pcache_RFC_V2.md
@@ -97,3 +97,7 @@ watch -n1 'dmsetup status pcache_sdb'
 umount /mnt
 dmsetup remove pcache_sdb
 ```
+
+## Test result
+
+We used the `pcache` test suite from **dtg-tests** to validate the target in various scenarios. The tests create pcache devices with different parameters, verify data read and write correctness and run xfstests under each configuration. Detailed results are available in the [test-result](./pcache_rfc_v2_result/results.html).


### PR DESCRIPTION
## Summary
- document pcache tests in `pcache_RFC_V2.md`

## Testing
- `script/validate-html` *(fails: cannot load such file -- w3c_validators)*
- `script/cibuild` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68419dd271108321b2c66fdc618fee0a