### PR TITLE
Document dm-pcache merge into mainline

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,9 @@ layout: default
 # PCache (Persistent memory as cache for block device)
 [PCache](pcache/pcache_index.md)
 
+Note: dm-pcache has been merged into Linux mainline:
+[dm-pcache merged commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1d57628ff95b32d5cfa8d8f50e07690c161e9cf0)
+
 <br><br>
 
 # CBD （CXL Block Device）


### PR DESCRIPTION
## Summary
- note that dm-pcache has been merged into the Linux mainline commit history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31bf4e7508321b0995235e0ce7c45